### PR TITLE
chore(docker): wrap the resulting asset in a docker container

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -64,8 +64,8 @@ branches:
     required_pull_request_reviews:
     required_status_checks:
       strict: true
-      contexts: [pre-commit, Create Release, 'Create Release Artifacts (aarch64, linux-gnu)', 'Create Release Artifacts (aarch64, linux-musl)', 'Create
-          Release Artifacts (x86_64, linux-gnu)', 'Create Release Artifacts (x86_64, linux-musl)']
+      contexts: [pre-commit, Create Release, Release / Create Release Artifacts (x86_64-unknown-linux-gnu), Release / Create Release Artifacts (aarch64-unknown-linux-gnu),
+        Release / Create Release Artifacts (x86_64-unknown-linux-musl), Release / Create Release Artifacts (aarch64-unknown-linux-musl)] # yamllint disable rule:indentation
     enforce_admins:
     required_linear_history: true
     restrictions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,11 +54,13 @@ jobs:
         token: ${{ secrets.GH_TOKEN }}
 
     - run: rsync -av --exclude=".*" atc-router/* .
+
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         target: ${{ matrix.target }}
         override: true
+
     - uses: actions-rs/cargo@v1
       env:
         RUSTFLAGS: -C target-feature=-crt-static     # Required for aarch64-unknown-linux-musl
@@ -66,15 +68,56 @@ jobs:
         use-cross: true
         command: build
         args: --release --target ${{ matrix.target }}
+
     - name: Install, Compress, and rename artifacts
       env:
         DESTDIR: ${{ env.DESTDIR }}
       run: |
         make install
         tar -C /tmp/build/ -czvf ${{ matrix.target }}.tar.gz .
+        tar -C /tmp/build/ -czvf atc-router.tar.gz .
+
     - name: Add Release Artifacts to the Github Release
       if: ${{ needs.release.outputs.published == 'true' }}
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ needs.release.outputs.release-git-tag }}
         files: ${{ matrix.target }}.tar.gz
+
+    - name: Log in to the Container registry
+      if: ${{ needs.release.outputs.published == 'true' }}
+      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - uses: docker/setup-qemu-action@v2
+      if: ${{ needs.release.outputs.published == 'true' }}
+
+    - uses: docker/setup-buildx-action@v2
+      if: ${{ needs.release.outputs.published == 'true' }}
+
+    - name: Docker meta
+      if: ${{ needs.release.outputs.published == 'true' }}
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ghcr.io/hutchic-org/atc-router-compiled
+        sep-tags: ' '
+        flavor: |
+          suffix=-${{ matrix.target }}
+        tags: |
+          type=sha
+          type=ref,event=branch
+          type=semver,pattern={{version}},value=${{ needs.release.outputs.release-git-tag }}
+          type=semver,pattern={{major}},value=${{ needs.release.outputs.release-git-tag }}
+
+    - name: Build and push
+      if: ${{ needs.release.outputs.published == 'true' }}
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        push: ${{ needs.release.outputs.published == 'true' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,3 @@
-ARG OSTYPE=linux-gnu
-ARG ARCHITECTURE=x86_64
-ARG DOCKER_REGISTRY=ghcr.io
-ARG DOCKER_IMAGE_NAME
+FROM scratch
 
-# List out all image permutations to trick dependabot
-FROM --platform=linux/amd64 kong/kong-build-tools:apk-1.8.1 as x86_64-linux-musl
-FROM --platform=linux/amd64 kong/kong-build-tools:rpm-1.8.1 as x86_64-linux-gnu
-FROM --platform=linux/arm64 kong/kong-build-tools:apk-1.8.1 as aarch64-linux-musl
-FROM --platform=linux/arm64 kong/kong-build-tools:rpm-1.8.1 as aarch64-linux-gnu
-
-
-# Run the build script
-FROM $ARCHITECTURE-$OSTYPE as build
-
-COPY . /src
-RUN /src/build.sh && /src/test.sh
-
-
-# Copy the build result to scratch so we can export the result
-FROM scratch as package
-
-COPY --from=build /tmp/build /
+ADD atc-router.tar.gz .


### PR DESCRIPTION
Wrap the resulting compiled / installed atc-router in a scratch docker image so we can use dependabot for downstream updates